### PR TITLE
Error fixes from first two weeks

### DIFF
--- a/Visiboole/Controllers/MainWindowController.cs
+++ b/Visiboole/Controllers/MainWindowController.cs
@@ -313,9 +313,10 @@ namespace VisiBoole.Controllers
                 }
                 DisplayController.DisplayOutput(output);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                DialogBox.New("Error", UnfoundErrorMessage, DialogType.Ok);
+                //DialogBox.New("Error", UnfoundErrorMessage, DialogType.Ok);
+                DialogBox.New("Error", ex.ToString(), DialogType.Ok);
             }
         }
 

--- a/Visiboole/Models/DesignHeader.cs
+++ b/Visiboole/Models/DesignHeader.cs
@@ -18,6 +18,11 @@ namespace VisiBoole.Models
         public bool Valid { get; set; }
 
         /// <summary>
+        /// Message describing the invalid header.
+        /// </summary>
+        public string InvalidMessage { get; set; }
+
+        /// <summary>
         /// Inputs of the design header.
         /// </summary>
         private List<string> Inputs;
@@ -47,9 +52,16 @@ namespace VisiBoole.Models
             Outputs = new List<string>();
             OutputSlots = new Dictionary<int, int>();
             Valid = true;
+            InvalidMessage = null;
         }
 
-        public void AddInput(int slot, string inputVariable)
+        /// <summary>
+        /// Attempts to add the provided input variable to the provided slot.
+        /// </summary>
+        /// <param name="slot"></param>
+        /// <param name="inputVariable"></param>
+        /// <returns>Whether the variable was added or not.</returns>
+        public bool AddInput(int slot, string inputVariable)
         {
             if (!Inputs.Contains(inputVariable))
             {
@@ -64,9 +76,17 @@ namespace VisiBoole.Models
                     InputSlots[slot]++;
                 }
             }
+
+            return true;
         }
 
-        public void AddOutput(int slot, string outputVariable)
+        /// <summary>
+        /// Attempts to add the provided output variable to the provided slot.
+        /// </summary>
+        /// <param name="slot"></param>
+        /// <param name="outputVariable"></param>
+        /// <returns>Whether the variable was added or not.</returns>
+        public bool AddOutput(int slot, string outputVariable)
         {
             if (!Outputs.Contains(outputVariable))
             {
@@ -80,6 +100,17 @@ namespace VisiBoole.Models
                 {
                     OutputSlots[slot]++;
                 }
+
+                return true;
+            }
+            else
+            {
+                // Set header to invalid
+                Valid = false;
+                // Set invalid message
+                InvalidMessage = $"'{outputVariable}' can not be used as an output twice.";
+                // Return false for error
+                return false;
             }
         }
 

--- a/Visiboole/ParsingEngine/Lexer.cs
+++ b/Visiboole/ParsingEngine/Lexer.cs
@@ -222,7 +222,7 @@ namespace VisiBoole.ParsingEngine
         /// <summary>
         /// Pattern for identifying concatenations.
         /// </summary>
-        public static readonly string ConcatPattern = $@"(\{{{VariableListPattern}\}})";
+        public static readonly string ConcatPattern = $@"(\{{\s*{VariableListPattern}\s*\}})";
 
         /// <summary>
         /// Pattern for identifying concatenations of any type or any type.
@@ -1738,7 +1738,7 @@ namespace VisiBoole.ParsingEngine
                             // Clear current lexeme
                             currentLexeme.Clear();
                         }
-                        // If current character is ~
+                        // If current lexeme is ~
                         else if (currentLexemeValue == "~")
                         {
                             // If current character is not ~
@@ -1751,13 +1751,13 @@ namespace VisiBoole.ParsingEngine
                             }
                             else
                             {
-                                // Clear current lexeme
-                                currentLexeme.Clear();
-                                // Continue and don't append
-                                continue;
+                                // Add unsupported error
+                                ErrorLog.Add(CurrentLineNumber, $"'~~' is not supported.");
+                                // Return null for error
+                                return null;
                             }
                         }
-                        // If current character is *
+                        // If current lexeme is *
                         else if (currentLexemeValue == "*")
                         {
                             // If current character is not *
@@ -1770,10 +1770,10 @@ namespace VisiBoole.ParsingEngine
                             }
                             else
                             {
-                                // Clear current lexeme
-                                currentLexeme.Clear();
-                                // Continue and don't append
-                                continue;
+                                // Add unsupported error
+                                ErrorLog.Add(CurrentLineNumber, $"'**' is not supported.");
+                                // Return null for error
+                                return null;
                             }
                         }
                         else if (currentLexemeValue == "==")
@@ -1832,17 +1832,24 @@ namespace VisiBoole.ParsingEngine
         /// </summary>
         /// <param name="lexemes">Lexeme list</param>
         /// <param name="index">Index of current lexeme</param>
+        /// <param name="skipEmpty">Indicates whether an empty lexeme should be skipped</param>
         /// <returns>Next non-empty lexeme</returns>
-        private string GetNextLexeme(List<string> lexemes, int index)
+        private string GetNextLexeme(List<string> lexemes, int index, bool skipEmpty)
         {
             for (int i = index + 1; i < lexemes.Count; i++)
             {
                 string lexeme = lexemes[i];
-                if (lexeme[0] != '\n' && lexeme[0] != ' ')
+
+                if (!skipEmpty)
+                {
+                    return lexeme;
+                }
+                else if (lexeme[0] != '\n' && lexeme[0] != ' ')
                 {
                     return lexeme;
                 }
             }
+
             return '\0'.ToString();
         }
         
@@ -1895,8 +1902,8 @@ namespace VisiBoole.ParsingEngine
             {
                 // Get the current lexeme
                 string currentLexeme = lexemes[i];
-                // Get the next non-empty lexeme
-                string nextLexeme = GetNextLexeme(lexemes, i);
+                // Get next lexeme
+                string nextLexeme = GetNextLexeme(lexemes, i, currentLexeme != "~" && currentLexeme != "*");
 
                 // Get token type of current lexeme
                 TokenType? tokenType = GetTokenType(currentLexeme, nextLexeme);


### PR DESCRIPTION
Fixed error handling for spaces around ~ and *.
Removed an instance of spaces around {} changing the behavior of the parser.
Fixed error handling for variables being used as a dependent twice.