### PR TITLE
More fixes

### DIFF
--- a/Visiboole/Models/Database.cs
+++ b/Visiboole/Models/Database.cs
@@ -429,14 +429,14 @@ namespace VisiBoole.ParsingEngine
         /// </summary>
         /// <param name="variables">Variables to set</param>
         /// <param name="binary">Values to set</param>
-        public void SetValues(IEnumerable<string> variables, string binary)
+        public void SetValues(IEnumerable<string> variables, string binary, bool tickAltClocks = true)
         {
             int i = -1;
             foreach (var variable in variables)
             {
                 if (GetValue(variable) != char.GetNumericValue(binary[++i]))
                 {
-                    SetValue(variable, binary[i] == '1');
+                    SetValue(variable, binary[i] == '1', tickAltClocks);
                 }
             }
         }
@@ -461,11 +461,11 @@ namespace VisiBoole.ParsingEngine
             }
         }
 
-        public void EvaluateExpressions()
+        public void EvaluateExpressions(bool tickAltClocks = true)
         {
             foreach (var expression in Expressions.Values)
             {
-                expression.Evaluate();
+                expression.Evaluate(tickAltClocks);
             }
         }
 

--- a/Visiboole/Models/DatabaseObjects/NamedExpression.cs
+++ b/Visiboole/Models/DatabaseObjects/NamedExpression.cs
@@ -267,8 +267,9 @@ namespace VisiBoole.Models
         /// <summary>
         /// Evaluates the expression and returns whether the value of the dependent was changed.
         /// </summary>
+        /// <param name="tickAltClocks">Indicates whether to tick alternate clocks</param>
         /// <returns>Whether the value of the dependent changed</returns>
-        public void Evaluate()
+        public void Evaluate(bool tickAltClocks = true)
         {
             // Get binary of expression value
             string expressionBinary = Convert.ToString(Solve(), 2);
@@ -284,7 +285,7 @@ namespace VisiBoole.Models
             // Store dependent binary
             DependentBinary = expressionBinary;
             // Set values
-            DesignController.ActiveDesign.Database.SetValues(Dependents, expressionBinary);
+            DesignController.ActiveDesign.Database.SetValues(Dependents, expressionBinary, tickAltClocks);
         }
     }
 }


### PR DESCRIPTION
Equal to expressions will now check for failed expansions.
] has became a separator of tokens.
Variables will continue to be initialized after an error is found.
Checks for implied and operations have been added.
Corrected a line number error when reporting line numbers.